### PR TITLE
fix(submit): use first commit as default PR title

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -334,8 +334,17 @@ func generateDefaultTitle(g *git.Git, base, branch string) string {
 		// Fall back to branch name
 		return generateTitleFromBranch(branch)
 	}
-	// Use the first commit's subject (oldest commit is last in array since GetCommits returns newest first)
-	return commits[len(commits)-1].Subject
+	// Use the first commit's subject.
+	// NOTE: GetCommits is defined to return commits in reverse chronological order (newest first),
+	// so the oldest commit in the range [base..branch] is the last element of the slice.
+	// See internal/git.GetCommits for the documented ordering guarantee.
+	// Trim whitespace to avoid malformed PR titles.
+	subject := strings.TrimSpace(commits[len(commits)-1].Subject)
+	if subject == "" {
+		// If the subject is empty or whitespace-only, fall back to branch name
+		return generateTitleFromBranch(branch)
+	}
+	return subject
 }
 
 // generateTitleFromBranch creates a PR title from a branch name.


### PR DESCRIPTION
The default PR title is now derived from the subject of the first
commit in the branch (the oldest commit unique to the branch) instead
of the branch name.

Falls back to the branch-name-based title if no commits are available.