### PR TITLE
fix: suppress help output on runtime errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,11 @@ var rootCmd = &cobra.Command{
 	Use:   "gh-stack",
 	Short: "Manage stacked pull requests",
 	Long:  `gh-stack tracks parent-child relationships between branches, enabling workflows where PRs target other PRs.`,
+	// SilenceUsage prevents Cobra from printing the help/usage text when a
+	// command's RunE returns an error.  Without this, any runtime error
+	// (e.g. a rebase conflict) causes the full usage output to be shown,
+	// which is confusing and unhelpful.
+	SilenceUsage: true,
 }
 
 // Execute runs the root command.


### PR DESCRIPTION
Cobra prints usage/help text by default when `RunE` returns an error. This meant any runtime error (e.g. a rebase conflict during `restack`) would dump a wall of irrelevant help output before the actual error message. Set `SilenceUsage: true` on the root command so help is only shown for actual usage errors.

Closes #35