### PR TITLE
fix!: normalize flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ Display the branch tree showing the stack hierarchy, current branch, and associa
 
 #### log Flags
 
-| Flag          | Description                           |
-| ------------- | ------------------------------------- |
-| `--all`       | Show all branches                     |
-| `--porcelain` | Machine-readable tab-separated output |
+| Flag              | Description                           |
+| ----------------- | ------------------------------------- |
+| `-a, --all`       | Show all branches                     |
+| `-p, --porcelain` | Machine-readable tab-separated output |
 
 #### Porcelain Format
 
@@ -197,10 +197,10 @@ gh stack create <name>
 
 #### create Flags
 
-| Flag            | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `-m, --message` | Commit message for staged changes               |
-| `--empty`       | Create branch without committing staged changes |
+| Flag              | Description                                     |
+| ----------------- | ----------------------------------------------- |
+| `-m, --message`   | Commit message for staged changes               |
+| `-C, --no-commit` | Create branch without committing staged changes |
 
 ### adopt
 
@@ -216,9 +216,9 @@ gh stack adopt <parent>
 
 #### adopt Flags
 
-| Flag       | Description                               |
-| ---------- | ----------------------------------------- |
-| `--branch` | Branch to adopt (default: current branch) |
+| Flag           | Description                               |
+| -------------- | ----------------------------------------- |
+| `-b, --branch` | Branch to adopt (default: current branch) |
 
 ### orphan
 
@@ -236,9 +236,9 @@ If no branch is specified, orphans the current branch.
 
 #### orphan Flags
 
-| Flag      | Description                 |
-| --------- | --------------------------- |
-| `--force` | Also orphan all descendants |
+| Flag          | Description                 |
+| ------------- | --------------------------- |
+| `-f, --force` | Also orphan all descendants |
 
 ### link
 
@@ -276,15 +276,15 @@ If a rebase conflict occurs, resolve it and run `gh stack continue`.
 
 #### submit Flags
 
-| Flag             | Description                                                              |
-| ---------------- | ------------------------------------------------------------------------ |
-| `--dry-run`      | Show what would happen without doing it                                  |
-| `--from [branch]` | Submit from this branch toward leaves (bare `--from` = current branch) |
-| `--current-only` | Only submit the current branch, not descendants                          |
-| `--update-only`  | Only update existing PRs, don't create new ones                          |
-| `--push-only`    | Skip PR creation/update, only restack and push                           |
-| `-y, --yes`      | Skip interactive prompts; use auto-generated PR title/description        |
-| `-w, --web`      | Open created/updated PRs in web browser                                  |
+| Flag                  | Description                                                            |
+| --------------------- | ---------------------------------------------------------------------- |
+| `-D, --dry-run`       | Show what would happen without doing it                                |
+| `-f, --from [branch]` | Submit from this branch toward leaves (bare `--from` = current branch) |
+| `-c, --current`       | Only submit the current branch, not descendants                        |
+| `-u, --update`        | Only update existing PRs, don't create new ones                        |
+| `-s, --skip-prs`      | Skip PR creation/update, only restack and push                         |
+| `-y, --yes`           | Skip interactive prompts; use auto-generated PR title/description      |
+| `--web`               | Open created/updated PRs in web browser                                |
 
 ### restack
 
@@ -296,11 +296,11 @@ If a rebase conflict occurs, resolve it and run `gh stack continue`.
 
 #### restack Flags
 
-| Flag          | Description                                              |
-| ------------- | -------------------------------------------------------- |
-| `--only`      | Only restack current branch, not descendants             |
-| `--dry-run`   | Show what would be done                                  |
-| `--worktrees` | Rebase branches checked out in linked worktrees in-place |
+| Flag              | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `-c, --current`   | Only restack current branch, not descendants             |
+| `-D, --dry-run`   | Show what would be done                                  |
+| `-w, --worktrees` | Rebase branches checked out in linked worktrees in-place |
 
 ### continue
 
@@ -322,11 +322,11 @@ This is the command to run when upstream changes have occurred (e.g., a PR in yo
 
 #### sync Flags
 
-| Flag           | Description                                              |
-| -------------- | -------------------------------------------------------- |
-| `--no-restack` | Skip restacking branches                                 |
-| `--dry-run`    | Show what would be done                                  |
-| `--worktrees`  | Rebase branches checked out in linked worktrees in-place |
+| Flag              | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `--no-restack`    | Skip restacking branches (might not work well!)          |
+| `-D, --dry-run`   | Show what would be done                                  |
+| `-w, --worktrees` | Rebase branches checked out in linked worktrees in-place |
 
 ### undo
 
@@ -346,10 +346,10 @@ Snapshots are stored in `.git/stack-undo/` and archived to `.git/stack-undo/done
 
 #### undo Flags
 
-| Flag        | Description                                  |
-| ----------- | -------------------------------------------- |
-| `--force`   | Skip confirmation prompt                     |
-| `--dry-run` | Show what would be restored without doing it |
+| Flag            | Description                                  |
+| --------------- | -------------------------------------------- |
+| `-f, --force`   | Skip confirmation prompt                     |
+| `-D, --dry-run` | Show what would be restored without doing it |
 
 ## Working with Git Worktrees
 

--- a/cmd/adopt.go
+++ b/cmd/adopt.go
@@ -26,7 +26,7 @@ By default, adopts the current branch. Use --branch to specify a different branc
 var adoptBranchFlag string
 
 func init() {
-	adoptCmd.Flags().StringVar(&adoptBranchFlag, "branch", "", "branch to adopt (default: current branch)")
+	adoptCmd.Flags().StringVarP(&adoptBranchFlag, "branch", "b", "", "branch to adopt (default: current branch)")
 	rootCmd.AddCommand(adoptCmd)
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -27,7 +27,7 @@ var (
 
 func init() {
 	createCmd.Flags().StringVarP(&createMessageFlag, "message", "m", "", "commit message for staged changes")
-	createCmd.Flags().BoolVar(&createEmptyFlag, "empty", false, "create branch without committing staged changes")
+	createCmd.Flags().BoolVarP(&createEmptyFlag, "no-commit", "C", false, "create branch without committing staged changes")
 	rootCmd.AddCommand(createCmd)
 }
 
@@ -77,7 +77,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	if hasStaged && !createEmptyFlag {
 		if createMessageFlag == "" {
-			return errors.New("staged changes found but no commit message provided; use -m or --empty")
+			return errors.New("staged changes found but no commit message provided; use -m or --no-commit")
 		}
 	}
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -162,15 +162,15 @@ func TestCreateEmptyWithStagedChanges(t *testing.T) {
 	os.WriteFile(f, []byte("content"), 0644)
 	exec.Command("git", "-C", dir, "add", f).Run()
 
-	// Create branch WITHOUT committing (--empty behavior)
+	// Create branch WITHOUT committing (--no-commit behavior)
 	g.CreateAndCheckout("feature-empty")
 	cfg.SetParent("feature-empty", trunk)
-	// Don't commit - this simulates --empty flag
+	// Don't commit - this simulates --no-commit flag
 
 	// Staged changes should still exist
 	hasStaged, _ := g.HasStagedChanges()
 	if !hasStaged {
-		t.Error("expected staged changes to remain with --empty")
+		t.Error("expected staged changes to remain with --no-commit")
 	}
 }
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -29,8 +29,8 @@ var (
 )
 
 func init() {
-	logCmd.Flags().BoolVar(&logAllFlag, "all", false, "show all branches")
-	logCmd.Flags().BoolVar(&logPorcelainFlag, "porcelain", false, "machine-readable output")
+	logCmd.Flags().BoolVarP(&logAllFlag, "all", "a", false, "show all branches")
+	logCmd.Flags().BoolVarP(&logPorcelainFlag, "porcelain", "p", false, "machine-readable output")
 	rootCmd.AddCommand(logCmd)
 }
 

--- a/cmd/orphan.go
+++ b/cmd/orphan.go
@@ -23,7 +23,7 @@ var orphanCmd = &cobra.Command{
 var orphanForceFlag bool
 
 func init() {
-	orphanCmd.Flags().BoolVar(&orphanForceFlag, "force", false, "also orphan all descendants")
+	orphanCmd.Flags().BoolVarP(&orphanForceFlag, "force", "f", false, "also orphan all descendants")
 	rootCmd.AddCommand(orphanCmd)
 }
 

--- a/cmd/restack.go
+++ b/cmd/restack.go
@@ -33,9 +33,9 @@ var (
 )
 
 func init() {
-	restackCmd.Flags().BoolVar(&restackOnlyFlag, "only", false, "only restack current branch, not descendants")
-	restackCmd.Flags().BoolVar(&restackDryRunFlag, "dry-run", false, "show what would be done")
-	restackCmd.Flags().BoolVar(&restackWorktreesFlag, "worktrees", false, "rebase branches checked out in linked worktrees in-place")
+	restackCmd.Flags().BoolVarP(&restackOnlyFlag, "current", "c", false, "only restack current branch, not descendants")
+	restackCmd.Flags().BoolVarP(&restackDryRunFlag, "dry-run", "D", false, "show what would be done")
+	restackCmd.Flags().BoolVarP(&restackWorktreesFlag, "worktrees", "w", false, "rebase branches checked out in linked worktrees in-place")
 	rootCmd.AddCommand(restackCmd)
 }
 

--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -73,18 +73,18 @@ type prDecision struct {
 	// pushAnyway is true when action is prActionSkip but a descendant branch
 	// will get a PR, so the branch must still exist on the remote as a base.
 	pushAnyway bool
-	// skipReason is set when action is prActionSkip ("update-only" or "user").
+	// skipReason is set when action is prActionSkip ("update" or "user").
 	skipReason string
 }
 
 func init() {
-	submitCmd.Flags().BoolVar(&submitDryRunFlag, "dry-run", false, "show what would be done without doing it")
-	submitCmd.Flags().BoolVar(&submitCurrentOnlyFlag, "current-only", false, "only submit current branch, not descendants")
-	submitCmd.Flags().BoolVar(&submitUpdateOnlyFlag, "update-only", false, "only update existing PRs, don't create new ones")
-	submitCmd.Flags().BoolVar(&submitPushOnlyFlag, "push-only", false, "skip PR creation/update, only restack and push")
+	submitCmd.Flags().BoolVarP(&submitDryRunFlag, "dry-run", "D", false, "show what would be done without doing it")
+	submitCmd.Flags().BoolVarP(&submitCurrentOnlyFlag, "current", "c", false, "only submit current branch, not descendants")
+	submitCmd.Flags().BoolVarP(&submitUpdateOnlyFlag, "update", "u", false, "only update existing PRs, don't create new ones")
+	submitCmd.Flags().BoolVarP(&submitPushOnlyFlag, "skip-prs", "s", false, "skip PR creation/update, only restack and push")
 	submitCmd.Flags().BoolVarP(&submitYesFlag, "yes", "y", false, "skip interactive prompts and use auto-generated title/description for PRs")
-	submitCmd.Flags().BoolVarP(&submitWebFlag, "web", "w", false, "open created/updated PRs in web browser")
-	submitCmd.Flags().StringVar(&submitFromFlag, "from", "", "submit from this branch toward leaves (default: entire stack; bare --from = current branch)")
+	submitCmd.Flags().BoolVar(&submitWebFlag, "web", false, "open created/updated PRs in web browser")
+	submitCmd.Flags().StringVarP(&submitFromFlag, "from", "f", "", "submit from this branch toward leaves (default: entire stack; bare --from = current branch)")
 	submitCmd.Flags().Lookup("from").NoOptDefVal = "HEAD"
 	rootCmd.AddCommand(submitCmd)
 }
@@ -94,13 +94,13 @@ func runSubmit(cmd *cobra.Command, args []string) error {
 
 	// Validate flag combinations
 	if submitPushOnlyFlag && submitUpdateOnlyFlag {
-		return errors.New("--push-only and --update-only cannot be used together: --push-only skips all PR operations")
+		return errors.New("--skip-prs and --update cannot be used together: --skip-prs skips all PR operations")
 	}
 	if submitPushOnlyFlag && submitWebFlag {
-		return errors.New("--push-only and --web cannot be used together: --push-only skips all PR operations")
+		return errors.New("--skip-prs and --web cannot be used together: --skip-prs skips all PR operations")
 	}
 	if submitFromFlag != "" && submitCurrentOnlyFlag {
-		return errors.New("--from and --current-only cannot be used together")
+		return errors.New("--from and --current cannot be used together: --current limits the scope to the current branch")
 	}
 
 	cwd, err := os.Getwd()
@@ -138,15 +138,15 @@ func runSubmit(cmd *cobra.Command, args []string) error {
 
 	// Collect branches to submit.
 	//
-	// --current-only: only the current branch (no descendants, no ancestors).
+	// --current: only the current branch (no descendants, no ancestors).
 	// --from (bare):  current branch + descendants (old default behavior).
 	// --from=<branch>: that branch + descendants.
 	// Default:         entire stack (all trunk descendants).
 	var branches []*tree.Node
 	if submitCurrentOnlyFlag {
-		// --current-only: submit only the current checked-out branch
+		// --current: submit only the current checked-out branch
 		if currentBranch == trunk {
-			return fmt.Errorf("cannot submit trunk branch %q; switch to a stack branch or remove --current-only", trunk)
+			return fmt.Errorf("cannot submit trunk branch %q; switch to a stack branch or remove --current", trunk)
 		}
 		node := tree.FindNode(root, currentBranch)
 		if node == nil {
@@ -280,7 +280,7 @@ func doSubmitPushAndPR(g *git.Git, cfg *config.Config, root *tree.Node, branches
 		decisionByName[d.node.Name] = d
 	}
 
-	// Phase 2: Push branches that will participate in PRs (or all if --push-only).
+	// Phase 2: Push branches that will participate in PRs (or all if --skip-prs).
 	fmt.Println(s.Bold("\n=== Phase 2: Push ==="))
 	for _, b := range branches {
 		var d *prDecision
@@ -306,7 +306,7 @@ func doSubmitPushAndPR(g *git.Git, cfg *config.Config, root *tree.Node, branches
 
 	if opts.PushOnly {
 		fmt.Println(s.Bold("\n=== Phase 3: PRs ==="))
-		fmt.Println(s.Muted("Skipped (--push-only)"))
+		fmt.Println(s.Muted("Skipped (--skip-prs)"))
 		return nil
 	}
 	return executePRDecisions(g, cfg, root, decisions, ghClient, opts, s)
@@ -326,7 +326,7 @@ func planPRDecisions(g *git.Git, cfg *config.Config, ghClient *github.Client, tr
 		case existingPR > 0:
 			out = append(out, &prDecision{node: b, parent: parent, action: prActionUpdate, prNum: existingPR})
 		case updateOnly:
-			out = append(out, &prDecision{node: b, parent: parent, action: prActionSkip, skipReason: "update-only"})
+			out = append(out, &prDecision{node: b, parent: parent, action: prActionSkip, skipReason: "update"})
 		case dryRun:
 			out = append(out, planPRDecisionDryRun(g, b, parent, trunk, s))
 		default:
@@ -447,14 +447,14 @@ func executePRDecisions(g *git.Git, cfg *config.Config, root *tree.Node, decisio
 		switch d.action {
 		case prActionSkip:
 			if opts.DryRun {
-				if d.skipReason == "update-only" {
-					fmt.Printf("Skipping %s %s\n", s.Branch(b.Name), s.Muted("(no existing PR, --update-only)"))
+				if d.skipReason == "update" {
+					fmt.Printf("Skipping %s %s\n", s.Branch(b.Name), s.Muted("(no existing PR, --update)"))
 				}
 				continue
 			}
 			switch d.skipReason {
-			case "update-only":
-				fmt.Printf("Skipping %s %s\n", s.Branch(b.Name), s.Muted("(no existing PR, --update-only)"))
+			case "update":
+				fmt.Printf("Skipping %s %s\n", s.Branch(b.Name), s.Muted("(no existing PR, --update)"))
 			case "user":
 				fmt.Printf("Skipped PR for %s %s\n", s.Branch(b.Name), s.Muted("(skipped)"))
 			}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -32,8 +32,8 @@ var (
 
 func init() {
 	syncCmd.Flags().BoolVar(&syncNoRestackFlag, "no-restack", false, "skip restacking branches")
-	syncCmd.Flags().BoolVar(&syncDryRunFlag, "dry-run", false, "show what would be done")
-	syncCmd.Flags().BoolVar(&syncWorktreesFlag, "worktrees", false, "rebase branches checked out in linked worktrees in-place")
+	syncCmd.Flags().BoolVarP(&syncDryRunFlag, "dry-run", "D", false, "show what would be done")
+	syncCmd.Flags().BoolVarP(&syncWorktreesFlag, "worktrees", "w", false, "rebase branches checked out in linked worktrees in-place")
 	rootCmd.AddCommand(syncCmd)
 }
 

--- a/cmd/undo.go
+++ b/cmd/undo.go
@@ -36,9 +36,9 @@ var (
 )
 
 func init() {
-	rootCmd.AddCommand(undoCmd)
 	undoCmd.Flags().BoolVarP(&undoForce, "force", "f", false, "Skip confirmation prompt")
-	undoCmd.Flags().BoolVar(&undoDryRun, "dry-run", false, "Show what would be restored without making changes")
+	undoCmd.Flags().BoolVarP(&undoDryRun, "dry-run", "D", false, "Show what would be restored without making changes")
+	rootCmd.AddCommand(undoCmd)
 }
 
 func runUndo(cmd *cobra.Command, args []string) error {

--- a/e2e/submit_test.go
+++ b/e2e/submit_test.go
@@ -76,8 +76,8 @@ func TestSubmitCurrentOnlyDryRun(t *testing.T) {
 
 	env.Git("checkout", "feat-a")
 
-	// Submit --current-only should NOT restack feat-b
-	result := env.MustRun("submit", "--dry-run", "--current-only")
+	// Submit --current should NOT restack feat-b
+	result := env.MustRun("submit", "--dry-run", "--current")
 
 	// Should mention feat-a but not feat-b in push phase
 	output := result.Stdout
@@ -85,7 +85,7 @@ func TestSubmitCurrentOnlyDryRun(t *testing.T) {
 		t.Error("expected feat-a push in output")
 	}
 	if strings.Contains(output, "Would push feat-b") {
-		t.Error("feat-b should not be pushed with --current-only")
+		t.Error("feat-b should not be pushed with --current")
 	}
 }
 
@@ -136,13 +136,13 @@ func TestSubmitUpdateOnlyDryRun(t *testing.T) {
 	env.MustRun("create", "feature-1")
 	env.CreateCommit("feature 1 work")
 
-	// With --update-only, should skip PR creation for branches without PRs
-	result := env.MustRun("submit", "--dry-run", "--update-only")
+	// With --update, should skip PR creation for branches without PRs
+	result := env.MustRun("submit", "--dry-run", "--update")
 
-	// Should not show "Would create PR" since update-only skips creation
+	// Should not show "Would create PR" since update skips creation
 	// (In dry-run, it should show the skip message)
 	if strings.Contains(result.Stdout, "Would create PR") {
-		t.Error("should not create PR with --update-only")
+		t.Error("should not create PR with --update")
 	}
 }
 
@@ -247,11 +247,11 @@ func TestSubmitFromTrunkCurrentOnlyFails(t *testing.T) {
 	// Go back to trunk
 	env.Git("checkout", "main")
 
-	// Submit --current-only from trunk should fail
-	result := env.Run("submit", "--dry-run", "--current-only")
+	// Submit --current from trunk should fail
+	result := env.Run("submit", "--dry-run", "--current")
 
 	if result.Success() {
-		t.Error("expected submit --current-only from trunk to fail")
+		t.Error("expected submit --current from trunk to fail")
 	}
 	if !strings.Contains(result.Stderr, "cannot submit trunk") {
 		t.Errorf("expected error about trunk, got: %s", result.Stderr)
@@ -281,7 +281,7 @@ func TestSubmitPushOnlyDryRun(t *testing.T) {
 	env.MustRun("create", "feature-1")
 	env.CreateCommit("feature 1 work")
 
-	result := env.MustRun("submit", "--dry-run", "--push-only")
+	result := env.MustRun("submit", "--dry-run", "--skip-prs")
 
 	// Should show all three phases
 	if !strings.Contains(result.Stdout, "Phase 1: Restack") {
@@ -295,13 +295,13 @@ func TestSubmitPushOnlyDryRun(t *testing.T) {
 	}
 
 	// Should show skipped message for PR phase
-	if !strings.Contains(result.Stdout, "Skipped (--push-only)") {
-		t.Error("expected 'Skipped (--push-only)' message")
+	if !strings.Contains(result.Stdout, "Skipped (--skip-prs)") {
+		t.Error("expected 'Skipped (--skip-prs)' message")
 	}
 
 	// Should NOT mention PR creation
 	if strings.Contains(result.Stdout, "Would create PR") {
-		t.Error("should not mention PR creation with --push-only")
+		t.Error("should not mention PR creation with --skip-prs")
 	}
 }
 
@@ -312,12 +312,12 @@ func TestSubmitPushOnlyWithUpdateOnlyFails(t *testing.T) {
 	env.MustRun("create", "feature-1")
 	env.CreateCommit("feature 1 work")
 
-	result := env.Run("submit", "--dry-run", "--push-only", "--update-only")
+	result := env.Run("submit", "--dry-run", "--skip-prs", "--update")
 
 	if result.Success() {
-		t.Error("expected --push-only and --update-only to fail")
+		t.Error("expected --skip-prs and --update to fail")
 	}
-	if !strings.Contains(result.Stderr, "--push-only and --update-only cannot be used together") {
+	if !strings.Contains(result.Stderr, "--skip-prs and --update cannot be used together") {
 		t.Errorf("expected error about conflicting flags, got: %s", result.Stderr)
 	}
 }
@@ -329,12 +329,12 @@ func TestSubmitPushOnlyWithWebFails(t *testing.T) {
 	env.MustRun("create", "feature-1")
 	env.CreateCommit("feature 1 work")
 
-	result := env.Run("submit", "--dry-run", "--push-only", "--web")
+	result := env.Run("submit", "--dry-run", "--skip-prs", "--web")
 
 	if result.Success() {
-		t.Error("expected --push-only and --web to fail")
+		t.Error("expected --skip-prs and --web to fail")
 	}
-	if !strings.Contains(result.Stderr, "--push-only and --web cannot be used together") {
+	if !strings.Contains(result.Stderr, "--skip-prs and --web cannot be used together") {
 		t.Errorf("expected error about conflicting flags, got: %s", result.Stderr)
 	}
 }
@@ -456,12 +456,12 @@ func TestSubmitFromAndCurrentOnlyMutualExclusion(t *testing.T) {
 	env.MustRun("create", "feat-a")
 	env.CreateCommit("a work")
 
-	result := env.Run("submit", "--dry-run", "--from=feat-a", "--current-only")
+	result := env.Run("submit", "--dry-run", "--from=feat-a", "--current")
 
 	if result.Success() {
-		t.Error("expected --from and --current-only to fail")
+		t.Error("expected --from and --current to fail")
 	}
-	if !strings.Contains(result.Stderr, "--from and --current-only cannot be used together") {
+	if !strings.Contains(result.Stderr, "--from and --current cannot be used together") {
 		t.Errorf("expected error about conflicting flags, got: %s", result.Stderr)
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: Some flags have changed. `restack`: `--only` is now `-c, --current`; `submit`: `--current-only` is now `-c, --current`, `--update-only` is now `-u, --update`, `--push-only` is now `-s, --skip-prs`, removed `-w` shorthand from `--web`.

Other options have had shorthands added; see [README.md](https://github.com/boneskull/gh-stack/blob/main/README.md) for details.