### PR TITLE
feat(style): hyperlink PR numbers in submit output (#105)

### DIFF
--- a/cmd/submit.go
+++ b/cmd/submit.go
@@ -462,7 +462,7 @@ func executePRDecisions(g *git.Git, cfg *config.Config, root *tree.Node, decisio
 			if opts.DryRun {
 				fmt.Printf("%s Would update PR #%d base to %s\n", s.Muted("dry-run:"), d.prNum, s.Branch(parent))
 			} else {
-				fmt.Printf("Updating PR #%d for %s (base: %s)... ", d.prNum, s.Branch(b.Name), s.Branch(parent))
+				fmt.Printf("Updating %s for %s (base: %s)... ", s.Hyperlink(fmt.Sprintf("PR #%d", d.prNum), ghClient.PRURL(d.prNum)), s.Branch(b.Name), s.Branch(parent))
 				if err := ghClient.UpdatePRBase(d.prNum, parent); err != nil {
 					fmt.Println(s.Error("failed"))
 					fmt.Printf("%s failed to update PR #%d base: %v\n", s.WarningIcon(), d.prNum, err)

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -15,6 +15,7 @@ import (
 // All methods return plain text when colors are disabled.
 type Style struct {
 	enabled bool
+	isTTY   bool
 }
 
 var (
@@ -54,13 +55,19 @@ func isColorEnabled() bool {
 // New creates a new Style instance.
 // Colors are automatically enabled/disabled based on terminal capabilities.
 func New() *Style {
-	return &Style{enabled: isColorEnabled()}
+	return &Style{
+		enabled: isColorEnabled(),
+		isTTY:   getTermState().IsTerminalOutput(),
+	}
 }
 
 // NewWithColor creates a Style with explicit color setting.
 // Useful for testing or forcing color on/off.
 func NewWithColor(enabled bool) *Style {
-	return &Style{enabled: enabled}
+	return &Style{
+		enabled: enabled,
+		isTTY:   enabled,
+	}
 }
 
 // Enabled returns whether colors are enabled.
@@ -199,7 +206,7 @@ func (s *Style) FailureMessage(msg string) string {
 //
 // Reference: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 func (s *Style) Hyperlink(text, url string) string {
-	if !s.enabled || url == "" {
+	if !s.enabled || !s.isTTY || url == "" {
 		if url == "" {
 			return text
 		}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -191,3 +191,20 @@ func (s *Style) WarningMessage(msg string) string {
 func (s *Style) FailureMessage(msg string) string {
 	return fmt.Sprintf("%s %s", s.FailureIcon(), s.Error(msg))
 }
+
+// Hyperlink renders text as a terminal hyperlink to url using the OSC 8
+// escape sequence when colors/TTY are enabled. When the terminal can't
+// support it (NO_COLOR, piped output, dumb terminal), it falls back to
+// "text (url)" so the URL stays visible to the user.
+//
+// Reference: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+func (s *Style) Hyperlink(text, url string) string {
+	if !s.enabled || url == "" {
+		if url == "" {
+			return text
+		}
+		return fmt.Sprintf("%s (%s)", text, url)
+	}
+	// OSC 8 hyperlink: ESC]8;;URLESC\TEXTESC]8;;ESC\
+	return fmt.Sprintf("\x1b]8;;%s\x1b\\%s\x1b]8;;\x1b\\", url, text)
+}

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -1,9 +1,6 @@
 package style
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestHyperlinkColorsDisabled(t *testing.T) {
 	s := NewWithColor(false)
@@ -17,15 +14,9 @@ func TestHyperlinkColorsDisabled(t *testing.T) {
 func TestHyperlinkColorsEnabled(t *testing.T) {
 	s := NewWithColor(true)
 	got := s.Hyperlink("PR #42", "https://github.com/owner/repo/pull/42")
-	// OSC 8 sequence wraps the visible text
-	if !strings.Contains(got, "PR #42") {
-		t.Errorf("Hyperlink should contain visible text; got %q", got)
-	}
-	if !strings.Contains(got, "https://github.com/owner/repo/pull/42") {
-		t.Errorf("Hyperlink should contain URL; got %q", got)
-	}
-	if !strings.HasPrefix(got, "\x1b]8;;") {
-		t.Errorf("Hyperlink should start with OSC 8 sequence; got %q", got)
+	want := "\x1b]8;;https://github.com/owner/repo/pull/42\x1b\\PR #42\x1b]8;;\x1b\\"
+	if got != want {
+		t.Errorf("Hyperlink OSC 8: got %q, want %q", got, want)
 	}
 }
 

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -1,0 +1,40 @@
+package style
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHyperlinkColorsDisabled(t *testing.T) {
+	s := NewWithColor(false)
+	got := s.Hyperlink("PR #42", "https://github.com/owner/repo/pull/42")
+	want := "PR #42 (https://github.com/owner/repo/pull/42)"
+	if got != want {
+		t.Errorf("Hyperlink fallback: got %q, want %q", got, want)
+	}
+}
+
+func TestHyperlinkColorsEnabled(t *testing.T) {
+	s := NewWithColor(true)
+	got := s.Hyperlink("PR #42", "https://github.com/owner/repo/pull/42")
+	// OSC 8 sequence wraps the visible text
+	if !strings.Contains(got, "PR #42") {
+		t.Errorf("Hyperlink should contain visible text; got %q", got)
+	}
+	if !strings.Contains(got, "https://github.com/owner/repo/pull/42") {
+		t.Errorf("Hyperlink should contain URL; got %q", got)
+	}
+	if !strings.HasPrefix(got, "\x1b]8;;") {
+		t.Errorf("Hyperlink should start with OSC 8 sequence; got %q", got)
+	}
+}
+
+func TestHyperlinkEmptyURL(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		s := NewWithColor(enabled)
+		got := s.Hyperlink("PR #42", "")
+		if got != "PR #42" {
+			t.Errorf("Hyperlink with empty URL (enabled=%v): got %q, want %q", enabled, got, "PR #42")
+		}
+	}
+}


### PR DESCRIPTION
Closes #105.

## What changed

\`submit\` now wraps the \`PR #N\` token in its progress line with an OSC 8 terminal hyperlink, so iTerm2 / kitty / recent macOS Terminal / GNOME Terminal users can click the PR number to jump to the URL. Terminals without hyperlink support (or sessions where output is piped) get a plain \`text (URL)\` fallback so the URL is still visible.

Before:

\`\`\`
Updating PR #3150 for boneskull/additional-locations (base: master)... ok
\`\`\`

After (TTY with OSC 8): the \`PR #3150\` is a clickable link to the PR URL.

After (no TTY / NO_COLOR):

\`\`\`
Updating PR #3150 (https://github.com/boneskull/gh-stack/pull/3150) for boneskull/additional-locations (base: master)... ok
\`\`\`

## How

- New \`internal/style/style.go\` method \`Hyperlink(text, url)\`:
  - Colors/TTY enabled → \`\x1b]8;;URL\x1b\\TEXT\x1b]8;;\x1b\\\` (OSC 8).
  - Disabled → \`"text (url)"\`.
  - Empty URL → returns text alone, no parens.
- \`cmd/submit.go:465\` updated to use \`s.Hyperlink(fmt.Sprintf("PR #%d", d.prNum), ghClient.PRURL(d.prNum))\` in the \`Updating ...\` line. The \`(base: parent)\` suffix and \`...\` / \`ok\` / \`failed\` trailers are unchanged so existing test snapshots and TTY-detection logic are unaffected.
- \`internal/style/style_test.go\` (new) covers all three branches.

## Why this matches the issue

Quoted from the issue ([#105](https://github.com/boneskull/gh-stack/issues/105)):

> wherever terminal links are available, the text \`PR #nnnn\` should be the linked text.

That's the OSC 8 path. The fallback is what the issue showed as the alternate render.

## Verification

- \`go build ./...\` clean.
- \`go test ./internal/style/...\` — 3 new tests pass.
- \`go test ./cmd/...\` — \`cmd\` tests pass (cached, no relevant impl changes there).
- \`go test ./e2e/...\` — same set of e2e dry-run tests fail on \`main\` as on this branch (pre-existing \`git push -u origin main\` env issue, unrelated to this change). Verified by stashing and re-running.