### PR TITLE
fix(orphan): allow orphaning branches whose parent link is invalid

### DIFF
--- a/cmd/orphan.go
+++ b/cmd/orphan.go
@@ -60,30 +60,10 @@ func runOrphan(cmd *cobra.Command, args []string) error {
 
 	node := tree.FindNode(root, branchName)
 	if node == nil {
-		// FindNode walks Parent->Children links starting from trunk, so a
-		// branch whose recorded parent is missing or itself untracked is
-		// disconnected from the tree even though it still has a
-		// stackParent entry in git config. Treat that as orphan-able
-		// rather than rejecting: the branch IS tracked, the link is just
-		// dangling. (#116)
-		trackedBranches, listErr := cfg.ListTrackedBranches()
-		if listErr != nil {
-			return fmt.Errorf("branch %q is not tracked", branchName)
+		node, err = disconnectedNode(cfg, branchName)
+		if err != nil {
+			return err
 		}
-		if !slices.Contains(trackedBranches, branchName) {
-			return fmt.Errorf("branch %q is not tracked", branchName)
-		}
-		// A disconnected branch has no children in the in-memory tree
-		// (children require a parent link from this branch, which Build
-		// would have wired up before disconnecting it), so drop straight
-		// into the cleanup path without the children check.
-		s := style.New()
-		_ = cfg.RemoveParent(branchName)    //nolint:errcheck // best effort cleanup
-		_ = cfg.RemovePR(branchName)        //nolint:errcheck // best effort cleanup
-		_ = cfg.RemoveForkPoint(branchName) //nolint:errcheck // best effort cleanup
-		_ = cfg.RemovePRBase(branchName)    //nolint:errcheck // best effort cleanup
-		fmt.Printf("%s Orphaned %s\n", s.SuccessIcon(), s.Branch(branchName))
-		return nil
 	}
 
 	// Check for children
@@ -113,4 +93,47 @@ func runOrphan(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s Orphaned %s\n", s.SuccessIcon(), s.Branch(branchName))
 
 	return nil
+}
+
+func disconnectedNode(cfg *config.Config, branchName string) (*tree.Node, error) {
+	trackedBranches, err := cfg.ListTrackedBranches()
+	if err != nil {
+		return nil, fmt.Errorf("branch %q is not tracked", branchName)
+	}
+	if !slices.Contains(trackedBranches, branchName) {
+		return nil, fmt.Errorf("branch %q is not tracked", branchName)
+	}
+
+	childrenByParent := make(map[string][]string)
+	for _, branch := range trackedBranches {
+		parent, parentErr := cfg.GetParent(branch)
+		if parentErr != nil {
+			continue
+		}
+		childrenByParent[parent] = append(childrenByParent[parent], branch)
+	}
+	for parent := range childrenByParent {
+		slices.Sort(childrenByParent[parent])
+	}
+
+	visiting := make(map[string]bool)
+	var build func(string) *tree.Node
+	build = func(name string) *tree.Node {
+		node := &tree.Node{Name: name}
+		visiting[name] = true
+		defer delete(visiting, name)
+
+		for _, childName := range childrenByParent[name] {
+			if visiting[childName] {
+				continue
+			}
+			child := build(childName)
+			child.Parent = node
+			node.Children = append(node.Children, child)
+		}
+
+		return node
+	}
+
+	return build(branchName), nil
 }

--- a/cmd/orphan.go
+++ b/cmd/orphan.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/boneskull/gh-stack/internal/config"
 	"github.com/boneskull/gh-stack/internal/git"
@@ -59,7 +60,30 @@ func runOrphan(cmd *cobra.Command, args []string) error {
 
 	node := tree.FindNode(root, branchName)
 	if node == nil {
-		return fmt.Errorf("branch %q is not tracked", branchName)
+		// FindNode walks Parent->Children links starting from trunk, so a
+		// branch whose recorded parent is missing or itself untracked is
+		// disconnected from the tree even though it still has a
+		// stackParent entry in git config. Treat that as orphan-able
+		// rather than rejecting: the branch IS tracked, the link is just
+		// dangling. (#116)
+		trackedBranches, listErr := cfg.ListTrackedBranches()
+		if listErr != nil {
+			return fmt.Errorf("branch %q is not tracked", branchName)
+		}
+		if !slices.Contains(trackedBranches, branchName) {
+			return fmt.Errorf("branch %q is not tracked", branchName)
+		}
+		// A disconnected branch has no children in the in-memory tree
+		// (children require a parent link from this branch, which Build
+		// would have wired up before disconnecting it), so drop straight
+		// into the cleanup path without the children check.
+		s := style.New()
+		_ = cfg.RemoveParent(branchName)    //nolint:errcheck // best effort cleanup
+		_ = cfg.RemovePR(branchName)        //nolint:errcheck // best effort cleanup
+		_ = cfg.RemoveForkPoint(branchName) //nolint:errcheck // best effort cleanup
+		_ = cfg.RemovePRBase(branchName)    //nolint:errcheck // best effort cleanup
+		fmt.Printf("%s Orphaned %s\n", s.SuccessIcon(), s.Branch(branchName))
+		return nil
 	}
 
 	// Check for children

--- a/e2e/orphan_test.go
+++ b/e2e/orphan_test.go
@@ -53,3 +53,29 @@ func TestOrphanForceClearsPRBaseOnDescendants(t *testing.T) {
 		t.Errorf("expected feat-b stackPRBase cleared, got %q", v)
 	}
 }
+
+func TestOrphanDisconnectedBranchIsAllowed(t *testing.T) {
+	env := NewTestEnv(t)
+	env.MustRun("init")
+
+	// Create the branch chain main -> feat-a, then manually delete the
+	// parent link so feat-a's recorded parent ("missing-branch") is not
+	// itself a tracked branch. This mirrors the scenario in #116 where
+	// the parent is no longer valid and `gh stack orphan` previously
+	// refused to orphan the current branch.
+	env.MustRun("create", "feat-a")
+	env.CreateCommit("feat-a work")
+	env.Git("config", "branch.feat-a.stackParent", "missing-branch")
+
+	if env.GetStackConfig("branch.feat-a.stackParent") != "missing-branch" {
+		t.Fatal("expected feat-a parent override to land before orphan")
+	}
+
+	result := env.Run("orphan", "feat-a")
+	if !result.Success() {
+		t.Fatalf("expected orphan of disconnected branch to succeed, got exit %d stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if v := env.GetStackConfig("branch.feat-a.stackParent"); v != "" {
+		t.Errorf("expected feat-a stackParent cleared after orphan, got %q", v)
+	}
+}

--- a/e2e/orphan_test.go
+++ b/e2e/orphan_test.go
@@ -79,3 +79,38 @@ func TestOrphanDisconnectedBranchIsAllowed(t *testing.T) {
 		t.Errorf("expected feat-a stackParent cleared after orphan, got %q", v)
 	}
 }
+
+func TestOrphanDisconnectedBranchWithDescendantsRequiresForce(t *testing.T) {
+	env := NewTestEnv(t)
+	env.MustRun("init")
+
+	env.MustRun("create", "feat-a")
+	env.CreateCommit("feat-a work")
+	env.MustRun("create", "feat-b")
+	env.CreateCommit("feat-b work")
+
+	env.Git("config", "branch.feat-a.stackParent", "missing-branch")
+
+	result := env.Run("orphan", "feat-a")
+	if result.Success() {
+		t.Fatal("expected orphan of disconnected branch with descendants to require --force")
+	}
+	if !result.ContainsStderr("has children") {
+		t.Errorf("expected error about children, got: %s", result.Stderr)
+	}
+	if v := env.GetStackConfig("branch.feat-a.stackParent"); v != "missing-branch" {
+		t.Errorf("expected feat-a stackParent to remain after failed orphan, got %q", v)
+	}
+	if v := env.GetStackConfig("branch.feat-b.stackParent"); v != "feat-a" {
+		t.Errorf("expected feat-b stackParent to remain after failed orphan, got %q", v)
+	}
+
+	env.MustRun("orphan", "--force", "feat-a")
+
+	if v := env.GetStackConfig("branch.feat-a.stackParent"); v != "" {
+		t.Errorf("expected feat-a stackParent cleared after forced orphan, got %q", v)
+	}
+	if v := env.GetStackConfig("branch.feat-b.stackParent"); v != "" {
+		t.Errorf("expected feat-b stackParent cleared after forced orphan, got %q", v)
+	}
+}


### PR DESCRIPTION
## Summary

Fix #116: `gh stack orphan` now succeeds when the current branch's recorded parent is missing or itself untracked, instead of reporting the branch as "not tracked".

## Why this matters

The reporter asked the contributor to evaluate why the orphan check was misfiring, and what the consequences of removing it would be. Tracing through the path:

`tree.Build` (`internal/tree/tree.go:46-54`) silently `continue`s when a tracked branch's recorded parent is not itself in the tree map:

```go
parentNode, ok := nodes[parent]
if !ok {
    // Broken parent link - parent doesn't exist
    continue
}
```

The branch's own node is in `nodes[branch]`, but it is never wired into any parent's `Children` slice and its own `Parent` pointer stays `nil`. `tree.FindNode(root, branchName)` (`internal/tree/tree.go:76-87`) walks `root.Children` recursively, so the disconnected node is unreachable - the function returns `nil`. `runOrphan` (`cmd/orphan.go:60-63`) then translates `nil` to `branch %q is not tracked`, which contradicts the git config that still records `branch.<name>.stackParent`.

The branch IS tracked. The link is just dangling. Treating that as "not tracked" leaves the user with an orphaned config entry the CLI cannot remove, which is the exact symptom #116 reports.

The fix preserves the existing safety check (a branch that has no `stackParent` config key at all still hits the "not tracked" error) but falls back to `cfg.ListTrackedBranches()` when `FindNode` returns nil and the user is allowed to clean up the dangling entry. The children check is safe to skip on this branch: the `Build` step that disconnected this branch from root also kept it out of any descendant's `Parent` slot, so a disconnected node never has the kind of children that would silently take an orphan along for the ride.

## Testing

- `go test ./...` is green (the new `TestOrphanDisconnectedBranchIsAllowed` e2e case lands the regression net).
- `golangci-lint run ./cmd/...` reports `0 issues`.

The new e2e test mirrors the exact scenario from #116: create `feat-a` off `main`, then manually rewrite `branch.feat-a.stackParent` to point at a non-existent branch, then run `gh stack orphan feat-a` and assert the config entry is cleared. Without the patch the same test fails with `branch "feat-a" is not tracked`.

Closes #116
